### PR TITLE
Add scoping for std::getline

### DIFF
--- a/tut/01/solutions/cat.cpp
+++ b/tut/01/solutions/cat.cpp
@@ -2,7 +2,7 @@
 
 int main() {
   std::string buffer;
-  getline(std::cin, buffer);
+  std::getline(std::cin, buffer);
   std::cout << buffer << "\n";
   return 0;
 }

--- a/tut/01/solutions/cat.cpp
+++ b/tut/01/solutions/cat.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 int main() {
   std::string buffer;


### PR DESCRIPTION
Don't want to have to explain ADL this early.